### PR TITLE
Added support for arbitrary depth of generalization in subclassed state machines

### DIFF
--- a/src/Magnum.Specs/Magnum.Specs.csproj
+++ b/src/Magnum.Specs/Magnum.Specs.csproj
@@ -80,7 +80,7 @@
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
       <HintPath>..\..\lib\Newtonsoft.Json\Net\Newtonsoft.Json.dll</HintPath>
     </Reference>
-     <Reference Include="nunit.framework, Version=2.5.2.9222, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.5.2.9222, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\nunit\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
@@ -281,6 +281,7 @@
     <Compile Include="StateMachine\OrderStateMachine.cs" />
     <Compile Include="StateMachine\Reflection_Specs.cs" />
     <Compile Include="StateMachine\StateVisualizer_Specs.cs" />
+    <Compile Include="StateMachine\GeneralizedStateMachine.cs" />
     <Compile Include="StateMachine\TestStateMachineInstance.cs" />
     <Compile Include="TypedKey_Specs.cs" />
     <Compile Include="Mapping_Specs.cs" />

--- a/src/Magnum.Specs/StateMachine/GeneralizedStateMachine.cs
+++ b/src/Magnum.Specs/StateMachine/GeneralizedStateMachine.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2007-2010 The Apache Software Foundation.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Magnum.Specs.StateMachine
+{
+    using System;
+    using Magnum.StateMachine;
+
+    [Serializable]
+    public abstract class AbstractStateMachine<TOne, TTwo, TSub> : StateMachine<TSub>
+        where TOne : class
+        where TTwo : class
+        where TSub : StateMachine<TSub>
+    {
+        protected static void Definition()
+        {
+            Initially(When(AnEvent).Then((x, y) => { }).TransitionTo(Intermediary));
+            During(Intermediary, When(AnEvent).Then((x, y) => { }));
+            During(Intermediary, When(TheFinalEvent).Then((x, y) => { }).TransitionTo(Completed));
+        }
+
+        public static State Initial { get; set; }
+        public static State Intermediary { get; set; }
+        public static State Completed { get; set; }
+
+        public static Event<TOne> AnEvent { get; set; }
+        public static Event<TTwo> TheFinalEvent { get; set; }
+    }
+
+
+    [Serializable]
+    public class SubclassedStateMachine : AbstractStateMachine<string, object, SubclassedStateMachine>
+    {
+        static SubclassedStateMachine()
+        {
+            Define(Definition);
+        }
+
+        public static State SubclassState { get; set; }
+        public static Event<string> SubclassEvent { get; set; }
+    }
+}

--- a/src/Magnum.Specs/StateMachine/State_Specs.cs
+++ b/src/Magnum.Specs/StateMachine/State_Specs.cs
@@ -87,5 +87,19 @@ namespace Magnum.Specs.StateMachine
             Assert.AreEqual(ExampleStateMachine.Completed, example.CurrentState);
         }
 
+        [Test]
+        public void Generalized_subclassed_state_machines_should_initialize_states_and_events_in_the_superclass()
+        {
+            new SubclassedStateMachine();
+
+            Assert.IsNotNull(SubclassedStateMachine.Initial);
+            Assert.IsNotNull(SubclassedStateMachine.Intermediary);
+            Assert.IsNotNull(SubclassedStateMachine.Completed);
+            Assert.IsNotNull(SubclassedStateMachine.AnEvent);
+            Assert.IsNotNull(SubclassedStateMachine.TheFinalEvent);
+
+            Assert.IsNotNull(SubclassedStateMachine.SubclassState);
+            Assert.IsNotNull(SubclassedStateMachine.SubclassEvent);
+        }
     }
 }

--- a/src/Magnum/StateMachine/StateMachine.cs
+++ b/src/Magnum/StateMachine/StateMachine.cs
@@ -257,7 +257,7 @@ namespace Magnum.StateMachine
 		private static void InitializeEvents()
 		{
 			Type machineType = typeof (T);
-			foreach (PropertyInfo propertyInfo in machineType.GetProperties(BindingFlags.Static | BindingFlags.Public))
+			foreach (PropertyInfo propertyInfo in machineType.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy))
 			{
 				if (IsPropertyABasicEvent(propertyInfo))
 				{
@@ -285,7 +285,7 @@ namespace Magnum.StateMachine
 		private static void InitializeStates()
 		{
 			Type machineType = typeof (T);
-			foreach (PropertyInfo propertyInfo in machineType.GetProperties(BindingFlags.Static | BindingFlags.Public))
+            foreach (PropertyInfo propertyInfo in machineType.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy))
 			{
 				if (!IsPropertyAState(propertyInfo)) continue;
 


### PR DESCRIPTION
The reflection code iterating properties in StateMachine.cs would only look at the subclass level in the case where the base class took the subclasse's type as a generic parameter.  I added BindingFlags.FlattenHeirarchy to the two loops to fix this.
