### PR TITLE
Allowed value types as event data

### DIFF
--- a/src/Magnum/StateMachine/DataEventAction.cs
+++ b/src/Magnum/StateMachine/DataEventAction.cs
@@ -18,7 +18,6 @@ namespace Magnum.StateMachine
 	public class DataEventAction<T, TData> :
 		EventActionBase<T>
 		where T : StateMachine<T>
-		where TData : class
 	{
 		private Func<TData, bool> _checkCondition = x => true;
 
@@ -80,7 +79,9 @@ namespace Magnum.StateMachine
 
 		protected override bool ParameterMeetsCondition(object parameter)
 		{
-			var eventData = parameter as TData;
+            if (!(parameter is TData))
+                return false;
+			var eventData = (TData) parameter;
 			if (eventData == null)
 				return false;
 

--- a/src/Magnum/StateMachine/EventActionList.cs
+++ b/src/Magnum/StateMachine/EventActionList.cs
@@ -47,7 +47,6 @@ namespace Magnum.StateMachine
 		}
 
 		public void Add<TData>(Action<T, TData> action, params ExceptionAction<T>[] exceptionActions)
-			where TData : class
 		{
 			_actions.Add(new ActionItem
 				{
@@ -57,7 +56,6 @@ namespace Magnum.StateMachine
 		}
 
 		public void Add<TData>(Action<T, DataEvent<T, TData>, TData> action, params ExceptionAction<T>[] exceptionActions)
-			where TData : class
 		{
 			_actions.Add(new ActionItem
 				{
@@ -76,7 +74,6 @@ namespace Magnum.StateMachine
 		}
 
 		public void Add<TData>(Expression<Action<T, TData>> expression, params ExceptionAction<T>[] exceptionActions)
-			where TData : class
 		{
 			_actions.Add(new ActionItem
 				{

--- a/src/Magnum/StateMachine/ExpressionAction.cs
+++ b/src/Magnum/StateMachine/ExpressionAction.cs
@@ -39,7 +39,6 @@ namespace Magnum.StateMachine
 	public class ExpressionAction<T, TData> :
 		EventAction<T>
 		where T : StateMachine<T>
-		where TData : class
 	{
 		private readonly Action<T, TData> _action;
 
@@ -53,7 +52,7 @@ namespace Magnum.StateMachine
 
 		public void Execute(T instance, Event @event, object parameter)
 		{
-			_action(instance, parameter as TData);
+            _action(instance, (parameter is TData) ? ((TData)parameter) : default(TData));
 		}
 	}
 }

--- a/src/Magnum/StateMachine/LambdaAction.cs
+++ b/src/Magnum/StateMachine/LambdaAction.cs
@@ -34,7 +34,6 @@ namespace Magnum.StateMachine
 	public class LambdaAction<T, TData> :
 		EventAction<T>
 		where T : StateMachine<T>
-		where TData : class
 	{
 		private readonly Action<T, DataEvent<T, TData>, TData> _action;
 
@@ -45,7 +44,7 @@ namespace Magnum.StateMachine
 
 		public void Execute(T instance, Event @event, object parameter)
 		{
-			_action(instance, @event as DataEvent<T, TData>, parameter as TData);
+			_action(instance, @event as DataEvent<T, TData>, (parameter is TData) ? ((TData) parameter) : default(TData));
 		}
 	}
 }

--- a/src/Magnum/StateMachine/StateMachine.cs
+++ b/src/Magnum/StateMachine/StateMachine.cs
@@ -194,7 +194,6 @@ namespace Magnum.StateMachine
 		/// </summary>
 		/// <param name="raised">The event that would be raised</param>
 		protected static DataEventAction<T, TData> When<TData>(Event<TData> raised)
-			where TData : class
 		{
 			DataEvent<T, TData> eevent = DataEvent<T, TData>.GetEvent(raised);
 


### PR DESCRIPTION
As far as I can see, there's no reason not to allow value types as event data. My use case is passing a single integer index as event data, without wrapping it into a class.
