### PR TITLE
Corrected ExtensionsForGenericArguments.GetAllProperties() extension method to return inherited property info once

### DIFF
--- a/src/Magnum.Specs/Magnum.Specs.csproj
+++ b/src/Magnum.Specs/Magnum.Specs.csproj
@@ -80,7 +80,7 @@
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
       <HintPath>..\..\lib\Newtonsoft.Json\Net\Newtonsoft.Json.dll</HintPath>
     </Reference>
-     <Reference Include="nunit.framework, Version=2.5.2.9222, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.5.2.9222, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\nunit\net-2.0\nunit.framework.dll</HintPath>
     </Reference>
@@ -249,6 +249,7 @@
     <Compile Include="Reflection\Benchmarks\ReflectionGetPropertyRunner.cs" />
     <Compile Include="Reflection\Benchmarks\GetNestedPropertyRunnerBase.cs" />
     <Compile Include="Reflection\Benchmarks\SafeGetNestedPropertyRunner.cs" />
+    <Compile Include="Reflection\ExtensionsToGenericArguments_Specs.cs" />
     <Compile Include="Reflection\ExtensionsToGenericTypes.cs" />
     <Compile Include="Reflection\FastProperty_Specs.cs" />
     <Compile Include="Reflection\GenericMethodInvoker_Specs.cs" />

--- a/src/Magnum.Specs/Reflection/ExtensionsToGenericArguments_Specs.cs
+++ b/src/Magnum.Specs/Reflection/ExtensionsToGenericArguments_Specs.cs
@@ -1,0 +1,63 @@
+﻿// Copyright 2007-2008 The Apache Software Foundation.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+namespace Magnum.Specs.Reflection
+{
+    using System.Linq;
+    using Magnum.Reflection;
+    using NUnit.Framework;
+
+    interface IFoo
+    {
+        string Text { get; set; }
+        int Number { get; }
+        object Object { set; }
+    }
+
+    interface IBar
+    {
+        float Float { get; set; }
+    }
+
+    interface IBaz : IBar
+    {
+        double Double { get; set; }
+    }
+
+    interface IComplexInterface : IFoo, IBaz
+    {
+        char Char { get; set; }
+    }
+
+    [TestFixture]
+    public class ExtensionsToGenericArguments_Specs
+    {
+        [Test]
+        public void ShouldReturnAllPublicPropertiesForInterface()
+        {
+            var expected = new[] { "Text", "Number", "Object" };
+            var actual = typeof(IFoo).GetAllProperties().Select(p => p.Name).ToArray();
+
+            Assert.That(actual, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void ShouldReturnAllPublicPropertiesForAllInterfacesInHierarchy()
+        {
+            var expected = new[] { "Text", "Number", "Object", "Float", "Double", "Char" };
+            var actual = typeof(IComplexInterface).GetAllProperties().Select(p => p.Name).ToArray();
+
+            Assert.That(actual, Is.EquivalentTo(expected));
+        }
+    }
+}

--- a/src/Magnum/Reflection/ExtensionsForGenericArguments.cs
+++ b/src/Magnum/Reflection/ExtensionsForGenericArguments.cs
@@ -14,6 +14,7 @@ namespace Magnum.Reflection
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Linq;
 	using System.Reflection;
 
 	public static class ExtensionsForGenericArguments
@@ -77,12 +78,10 @@ namespace Magnum.Reflection
 
 			if (type.IsInterface)
 			{
-				foreach (Type interfaceType in type.GetInterfaces())
+				foreach (PropertyInfo propertyInfo in type.GetInterfaces()
+					.SelectMany(interfaceType => interfaceType.GetProperties(bindingFlags)))
 				{
-					foreach (PropertyInfo propertyInfo in interfaceType.GetAllProperties())
-					{
-						yield return propertyInfo;
-					}
+					yield return propertyInfo;
 				}
 			}
 		}


### PR DESCRIPTION
Example:
interface IBar {    float Float { get; set; }}
interface IBaz : IBar { double Double { get; set; } }
interface IFoo : IBaz { char Char { get; set; } }

Before fix, GetAllProperties() will return Float property twice for IFoo interface
