### PR TITLE
Handle generic type definitions that do not contain a backtick

### DIFF
--- a/src/Magnum.Specs/Extensions/TypeExtension_Specs.cs
+++ b/src/Magnum.Specs/Extensions/TypeExtension_Specs.cs
@@ -12,114 +12,125 @@
 // specific language governing permissions and limitations under the License.
 namespace Magnum.Specs.Extensions
 {
-	using System;
-	using Magnum.Extensions;
-	using NUnit.Framework;
-	using TestFramework;
+    using System;
+    using Magnum.Extensions;
+    using NUnit.Framework;
+    using TestFramework;
 
 
-	[TestFixture]
-	public class An_object_that_implements_a_generic_interface
-	{
-		[Test]
-		public void Should_match_a_generic_base_class_implementation_of_the_interface()
-		{
-			typeof(NonGenericSubClass).Implements<IGeneric<int>>().ShouldBeTrue();
-		}
+    [TestFixture]
+    public class An_object_that_implements_a_generic_interface
+    {
+        [Test]
+        public void Should_match_a_generic_base_class_implementation_of_the_interface()
+        {
+            typeof(NonGenericSubClass).Implements<IGeneric<int>>().ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_generic_interface()
-		{
-			typeof(GenericClass).Implements<IGeneric<int>>().ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_generic_interface()
+        {
+            typeof(GenericClass).Implements<IGeneric<int>>().ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_by_type_argument_on_an_object()
-		{
-			new GenericClass().Implements(typeof(INotGeneric)).ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_by_type_argument_on_an_object()
+        {
+            new GenericClass().Implements(typeof(INotGeneric)).ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_on_an_object()
-		{
-			new GenericClass().Implements<INotGeneric>().ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_on_an_object()
+        {
+            new GenericClass().Implements<INotGeneric>().ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_using_the_generic_argument()
-		{
-			typeof(GenericClass).Implements<INotGeneric>().ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_using_the_generic_argument()
+        {
+            typeof(GenericClass).Implements<INotGeneric>().ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_using_the_generic_argument_on_a_subclass()
-		{
-			typeof(GenericSubClass).Implements<INotGeneric>().ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_using_the_generic_argument_on_a_subclass()
+        {
+            typeof(GenericSubClass).Implements<INotGeneric>().ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_using_the_type_argument()
-		{
-			typeof(GenericClass).Implements(typeof(INotGeneric)).ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_using_the_type_argument()
+        {
+            typeof(GenericClass).Implements(typeof(INotGeneric)).ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_a_regular_interface_using_the_type_argument_on_a_subclass()
-		{
-			typeof(GenericSubClass).Implements(typeof(INotGeneric)).ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_a_regular_interface_using_the_type_argument_on_a_subclass()
+        {
+            typeof(GenericSubClass).Implements(typeof(INotGeneric)).ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_an_open_generic_interface()
-		{
-			typeof(GenericClass).Implements(typeof(IGeneric<>)).ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_an_open_generic_interface()
+        {
+            typeof(GenericClass).Implements(typeof(IGeneric<>)).ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_match_an_open_generic_interface_in_a_base_class()
-		{
-			typeof(NonGenericSubClass).Implements(typeof(IGeneric<>)).ShouldBeTrue();
-		}
+        [Test]
+        public void Should_match_an_open_generic_interface_in_a_base_class()
+        {
+            typeof(NonGenericSubClass).Implements(typeof(IGeneric<>)).ShouldBeTrue();
+        }
 
-		[Test]
-		public void Should_not_match_a_regular_interface_that_is_not_implemented()
-		{
-			typeof(GenericClass).Implements<IDisposable>().ShouldBeFalse();
-		}
+        [Test]
+        public void Should_not_match_a_regular_interface_that_is_not_implemented()
+        {
+            typeof(GenericClass).Implements<IDisposable>().ShouldBeFalse();
+        }
 
+        [Test]
+        public void Should_return_short_type_name_for_generic_class()
+        {
+            typeof(GenericClass).ToShortTypeName().ShouldNotBeNull();
+        }
 
-		interface INotGeneric
-		{
-		}
+        [Test]
+        public void Should_return_short_type_name_for_nongeneric_class()
+        {
+            typeof(NonGenericSubClass).ToShortTypeName().ShouldNotBeNull();
+        }
 
-
-		interface IGeneric<T>
-		{
-		}
-
-
-		class GenericClass :
-			IGeneric<int>,
-			INotGeneric
-		{
-		}
-
-
-		class GenericSubClass :
-			GenericClass
-		{
-		}
+        interface INotGeneric
+        {
+        }
 
 
-		class GenericBaseClass<T> :
-			IGeneric<T>
-		{
-		}
+        interface IGeneric<T>
+        {
+        }
 
 
-		class NonGenericSubClass :
-			GenericBaseClass<int>
-		{
-		}
-	}
+        class GenericClass :
+            IGeneric<int>,
+            INotGeneric
+        {
+        }
+
+
+        class GenericSubClass :
+            GenericClass
+        {
+        }
+
+
+        class GenericBaseClass<T> :
+            IGeneric<T>
+        {
+        }
+
+
+        class NonGenericSubClass :
+            GenericBaseClass<int>
+        {
+        }
+    }
 }

--- a/src/Magnum.Specs/Extensions/TypeExtension_Specs.cs
+++ b/src/Magnum.Specs/Extensions/TypeExtension_Specs.cs
@@ -99,6 +99,17 @@ namespace Magnum.Specs.Extensions
             typeof(NonGenericSubClass).ToShortTypeName().ShouldNotBeNull();
         }
 
+        [Test]
+        public void Should_return_short_type_name_for_generic_class_with_no_backtick()
+        {
+            typeof(Outer<int>.Inner).ToShortTypeName().ShouldNotBeNull();
+        }
+
+        static class Outer<T>
+        {
+            public class Inner { }
+        }
+
         interface INotGeneric
         {
         }

--- a/src/Magnum/Extensions/ExtensionsToType.cs
+++ b/src/Magnum/Extensions/ExtensionsToType.cs
@@ -43,7 +43,7 @@ namespace Magnum.Extensions
 			if (type.IsGenericType)
 			{
 				string name = type.GetGenericTypeDefinition().Name;
-				name = name.Substring(0, name.IndexOf('`'));
+			    name = name.Contains('`') ? name.Substring(0, name.IndexOf('`')) : name;
 
 				Type[] arguments = type.GetGenericArguments();
 				string innerTypeName = string.Join(",", arguments.Select(x => x.ToShortTypeName()).ToArray());


### PR DESCRIPTION
I came across a bug when using Masstransit in which Consumes<>.Context caused an exception to be thrown by ToShortTypeName because the generic type definition did not contain a backtick (I believe Masstransit is calling ToShortTypeName on the base type). Rather than guess whether that was right or wrong, I figured it would be easiest to go on the defensive and account for generic type definitions that do not contain a backtick. I also added some test cases to cover basic functionality as well as #22.

It would appear that though I didn't break line endings, I did inadvertently break your tabs by replacing them with spaces. If you want me to fix this let me know and I'll amend the PR. 
