### PR TITLE
fix bug in Stringify for objects with indexers

### DIFF
--- a/src/Magnum/Extensions/ExtensionsToObject.cs
+++ b/src/Magnum/Extensions/ExtensionsToObject.cs
@@ -70,6 +70,7 @@ namespace Magnum.Extensions
 			string[] elements = value
 				.GetType()
 				.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+				.Where(x=>!x.GetIndexParameters().Any())
 				.Select(x => "{0} = {1}".FormatWith(x.Name, StringifyInternal(x.GetValue(value, null), recursionLevel - 1)))
 				.ToArray();
 


### PR DESCRIPTION
Ran into this bug while using Mass Transit - objects with indexers lead to a reflection parameter exception (since GetValue is called with no parameters and indexers look like properties with parameters).
