### PR TITLE
Use UTC time for generating sequential GUIDs in international systems…

### DIFF
--- a/src/Magnum/CombGuid.cs
+++ b/src/Magnum/CombGuid.cs
@@ -23,7 +23,7 @@ namespace Magnum
 		{
 			byte[] guidArray = Guid.NewGuid().ToByteArray();
 
-			DateTime now = DateTime.Now;
+			DateTime now = DateTime.UtcNow;
 
 			// Get the days and milliseconds which will be used to build the byte string 
 			var days = new TimeSpan(now.Ticks - _baseDate.Ticks);


### PR DESCRIPTION
… over multiple time zones.

This is not a _huge_ problem for me, but ComGuids are being generated out of sequence due to time skew. It will still be inserted on the DB out of sequence (and fragment indexes) due to persistence delay. Only less likely with this change.
